### PR TITLE
創作物ページのアクセス設定の修正

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top]
+  skip_before_action :require_login, only: %i[top, portfolio]
   def top
     @articles = Article.order(created_at: :desc)
   end


### PR DESCRIPTION
# 概要
創作物ページに正常にアクセスできなかった問題を修正

# 詳細
静的ページ用のコントローラー内の設定で、創作物ページへのアクセスにログインが必要な状態になっていた為、修正