### PR TITLE
トップページにアクセスできない問題を修正

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top, portfolio]
+  skip_before_action :require_login, only: %i[top portfolio]
   def top
     @articles = Article.order(created_at: :desc)
   end


### PR DESCRIPTION
# 概要
トップページに正常にアクセスできない問題の修正を実行

# 詳細
PagesController内の記述ミスにより、リダイレクトエラーを起こし、トップページに到達できないエラーが発生していた為修正