### PR TITLE
記事内の表が正常に表示されるように設定

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -122,6 +122,30 @@ article {
         display: block;
         margin: 0 auto;
     }
+    thead {
+        display: table-header-group;
+        vertical-align: middle;
+    }
+    tbody {
+        display: table-row-group;
+        vertical-align: middle;
+    }
+    tr {
+        display: table-row;
+        vertical-align: inherit;
+        border: solid 1px;
+    }
+    th, td {
+        display: table-cell;
+        vertical-align: inherit;
+        border: solid 1px;
+        text-align: center;
+    }
+    table {
+        border-collapse: collapse;
+        max-width: 100%;
+        border-color: #666665;
+    }
     .share-area {
         margin-bottom: 48px;
     }

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -15,6 +15,6 @@
     </div>
   </div>
   <div>
-    <%= sanitize(@article.content, tags: %w(p br h1 h2 h3 strong em b i u ol ul li a blockquote img iframe div pre code), attributes: %w(href src alt style width height title frameborder allow allowfullscreen target rel class)) %>
+    <%= sanitize(@article.content, tags: %w(p br h1 h2 h3 strong em b i u ol ul li a blockquote img iframe div pre code table colgroup col tbody tr td), attributes: %w(href src alt style width height title frameborder allow allowfullscreen target rel class)) %>
   </div>
 </article>


### PR DESCRIPTION
# 概要
記事内で表示される表(テーブル)のデザインが崩れて表示されていた問題を修正

# 詳細
記事内で表示される表が正常に表示されなかった為、記事用のビューファイルとスタイルシートを修正